### PR TITLE
Render jinja2 automatically if template tags appear in SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sqla-raw
 
-I've copy-pasted this enough times that it seemed worth packaging. Really not much more than a single method (`raw.db.result`) to submit SQL to a database using a SQLAlchemy engine connection, and get results as a list of dictionaries, with each dict keyed by result set column names.
+I've copy-pasted this enough times that it seemed worth packaging. Really not much more than a single method (`raw.db.result`) making it e-z to submit raw SQL to a database using a SQLAlchemy engine connection. Returns results as a list of dictionaries, with each dict keyed by column names. `result_from_file` is almost the same except it takes a path to read the query from.
 
 ## Installation
 
@@ -17,6 +17,6 @@ Configure your database connection string by setting `$DATABASE_URL` in your env
 [{'version': 'PostgreSQL 10.10 on x86_64-apple-darwin14.5.0, compiled by Apple LLVM version 7.0.0 (clang-700.1.76), 64-bit'}]
 ```
 
-Because it's SQLAlchemy, you can use named parameters in your SQL string with colon-prepended `:key` format, and assign values in `kwargs`.
+Because it's SQLAlchemy, you can safely use named parameters in your SQL string with colon-prepended `:key` format, and assign values in `kwargs`.
 
-Also, by setting optional parameter `jinja=True`, you can use Jinja2 templating syntax to interpolate the query, if desired. (It uses a `SandboxedEnvironment`, but avoid this option with untrusted inputs, for obvious reasons.)
+You can also use Jinja2 templating syntax to interpolate the query, if desired. (It uses a `SandboxedEnvironment`, but avoid this option with untrusted inputs, for obvious reasons.)

--- a/raw/db.py
+++ b/raw/db.py
@@ -27,7 +27,12 @@ def process_template(obj, **kwargs):
 
 
 def result(sql, **kwargs):
-    """"""
+    """Submit SQL to the engine connection and return results as list of dicts
+
+    Usage:
+        `sql` - a string containing valid SQL for submission to the database
+        `kwargs` - key/values pairs assigning values to any named parameters in the query
+    """
     try:
         with connect() as conn:
             # Render with jinja if template tags appear in query body
@@ -51,6 +56,7 @@ def result(sql, **kwargs):
 
 
 def result_from_file(path, **kwargs):
+    """Read SQL from file at `path` and submit via `result()` method"""
     # If path doesn't exist
     if not os.path.exists(path):
         rows = [{"error": f"File '{path}' not found!"}]
@@ -69,10 +75,7 @@ def result_from_file(path, **kwargs):
 
 
 if __name__ == "__main__":
-    """Calling module directly runs a tiny test.
-    `result_from_file` calls `result` so this invokes most of the code above
-    (except for the jinja part)
-    """
+    """Calling module directly runs a tiny test."""
     from tempfile import NamedTemporaryFile
 
     os.environ["DATABASE_URL"] = "sqlite:///"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = "https://github.com/tym-xqo/sqla-raw"
 EMAIL = "thomas@yager-madden.com"
 AUTHOR = "Thomas Yager-Madden"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 
 REQUIRED = [
     "jinja2",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = "https://github.com/tym-xqo/sqla-raw"
 EMAIL = "thomas@yager-madden.com"
 AUTHOR = "Thomas Yager-Madden"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 
 REQUIRED = [
     "jinja2",


### PR DESCRIPTION
The `jinja` arg to `result()` was clunky UI, and led to unpleasant errors if there's jinja in the SQL but the arg is set to `False`. Instead, this revision looks for a simple regex `{%.*%}` which should detect template tags in the SQL code (and seems unlikely to appear in normal non-jinja-fied SQL).