### PR TITLE
Add `returns` arg to db.results() method

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 90

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # sqla-raw
 
-An opinionated, minimalist library for fetching data from a [SQLAlchemy](https://www.sqlalchemy.org/) connection, when you don't need or want an ORM. You know how to write SQL; `sqla-raw` makes it simple to send that SQL to your database and get results.
+An opinionated, minimalist library for fetching data from a [SQLAlchemy](https://www.sqlalchemy.org/) connection, when you don't need or want an ORM. You know how to write SQL; `sqla-raw` makes it [E-Z](https://media.giphy.com/media/zcCGBRQshGdt6/source.gif) to send that raw SQL to your database and get results, saving a lot of DBAPI boilerplate and providing a simple and consistent interface with a result format that is straightfoward to introspect.
 
-Really not much more than a single method (`raw.db.result()`) making it [E-Z](https://media.giphy.com/media/zcCGBRQshGdt6/source.gif) to submit raw SQL via a SQLAlchemy [Engine](https://docs.sqlalchemy.org/en/latest/core/connections.html#sqlalchemy.engine.Engine). By default, `db.result()` returns all results as a list of dictionaries, keyed by column names. (See __'Usage'__ below for other options)
+Really not much more than a single method (`raw.db.result()`) that submits raw SQL via a SQLAlchemy [Engine](https://docs.sqlalchemy.org/en/latest/core/connections.html#sqlalchemy.engine.Engine) connection. By default, `db.result()` returns all results as a list of dictionaries, keyed by column names. (See __'Usage'__ below for other options)
 
-As a convenience, `result_from_file()` is about the same except it reads your query from a given path, rather than taking a SQL string argument directly. Contents of the file are handed off to `result()` so the rest functions identitically.
+As a convenience, `result_from_file()` is about the same except that it reads your query from a given path, rather than taking a SQL string argument directly. Contents of the file are handed off to `result()` so the rest functions identitically.
 
-Engine creation is handled implicitly by the first call to `result()`; any subsequent calls use a connection from the pool. The connection string for the Engine is set by `DATABASE_URL` in the environment. (All other Engine settings are defaults. Affording explicit opening and closing of the Engine and the setting of other parameters might be a useful area for further development, if it can be kept simple.)
+Engine instantiation is handled implicitly by the first call to `result()`; any subsequent calls use a connection from the pool. The connection string for the Engine is set by `DATABASE_URL` in the environment. All other Engine settings use SQLAlchemy defaults. (Affording explicit creation and disposal of the Engine and exposing the setting of other parameters might be a useful area for further development, if it can be kept simple.)
 
 ## Installation
 
@@ -36,7 +36,7 @@ You can also use [Jinja2](https://palletsprojects.com/p/jinja/) templating synta
 
 ### Options
 
-Passing argument `returns` to `db.result()` (or `result_from_file()`) overrides the default result formatting: `returns="tuples"` brings back a list of tuples with row values instead of dictionaries, and `returns="proxy"` returns the plain SQLAlchemy [ResultProxy](https://docs.sqlalchemy.org/en/latest/core/connections.html?highlight=resultproxy#sqlalchemy.engine.ResultProxy) object directly, for further handling by the caller. `"proxy"` allows access to methods (e.g. `fetchone()` or `fetchmany()` ) that `sqla-raw` default usage hides behind its facade; it can also be good for SQL statements (like `inserts` without `returning` or DDL) that are not expected to return results — although by default these will return an empty list.
+Passing argument `returns` to `db.result()` (or `result_from_file()`) overrides the default result formatting: `returns="tuples"` brings back a list of tuples with row values instead of dictionaries, and `returns="proxy"` returns the plain SQLAlchemy [ResultProxy](https://docs.sqlalchemy.org/en/latest/core/connections.html?highlight=resultproxy#sqlalchemy.engine.ResultProxy) object directly, for further handling by the caller. The `"proxy"` option allows access to methods (e.g. `fetchone()` or `fetchmany()` ) that `sqla-raw` default usage hides behind its facade; it can also be good for SQL statements (such as `inserts` without `returning` or DDL) that are not expected to return results — although by default these will return an empty list.
 
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # sqla-raw
 
-An opinionated, minimalist library for fetching data from a [SQLAlchemy](https://www.sqlalchemy.org/) connection, when you don't need or want an ORM. You know how to write SQL; `sqla-raw` wants to make it as simple as possible to send that SQL to your database and get results.
+An opinionated, minimalist library for fetching data from a [SQLAlchemy](https://www.sqlalchemy.org/) connection, when you don't need or want an ORM. You know how to write SQL; `sqla-raw` makes it simple to send that SQL to your database and get results.
 
-Really not much more than a single method (`raw.db.result`) making it E-Z to submit raw SQL via a sqla [Engine](https://docs.sqlalchemy.org/en/13/core/connections.html#sqlalchemy.engine.Engine). Returns results as a list of dictionaries, with each dict keyed by column names. 
+Really not much more than a single method (`raw.db.result()`) making it [E-Z](https://media.giphy.com/media/zcCGBRQshGdt6/source.gif) to submit raw SQL via a SQLAlchemy [Engine](https://docs.sqlalchemy.org/en/latest/core/connections.html#sqlalchemy.engine.Engine). By default, `db.result()` returns all results as a list of dictionaries, keyed by column names. (See __'Usage'__ below for other options)
 
-As a further convenience, `result_from_file` is almost the same except it will read the query from a given path, rather than taking a SQL string argument directly.
+As a convenience, `result_from_file()` is about the same except it reads your query from a given path, rather than taking a SQL string argument directly. Contents of the file are handed off to `result()` so the rest functions identitically.
+
+Engine creation is handled implicitly by the first call to `result()`; any subsequent calls use a connection from the pool. The connection string for the Engine is set by `DATABASE_URL` in the environment. (All other Engine settings are defaults. Affording explicit opening and closing of the Engine and the setting of other parameters might be a useful area for further development, if it can be kept simple.)
 
 ## Installation
 
@@ -21,16 +23,22 @@ Configure your database connection string by setting `$DATABASE_URL` in your env
 [{'version': 'PostgreSQL 10.10 on x86_64-apple-darwin14.5.0, compiled by Apple LLVM version 7.0.0 (clang-700.1.76), 64-bit'}]
 ```
 
-Because it's SQLAlchemy, you can safely use named parameters in your SQL string with colon-prepended `:key` format, and assign values in `kwargs`.
+Because it's SQLAlchemy, you can safely use [named parameters](https://docs.sqlalchemy.org/en/latest/core/sqlelement.html?highlight=textclause#sqlalchemy.sql.expression.TextClause.bindparams) in your SQL string with colon-prepended `:key` format, and assign values in `kwargs`.
 
 ```python
 >>> db.result('select :foo as bar', foo='baz')
 [{'bar': 'baz'}]
 ```
 
-You can also use Jinja2 templating syntax to interpolate the query, if desired. `db.result()` simply inspects the query for template tags (`"{%.*%}"`) and renders the template to SQL before submitting. (It uses a `SandboxedEnvironment` for some measure of injection safety, but avoid this option with untrusted inputs, for obvious reasons.)
+### Jinja templating
+
+You can also use [Jinja2](https://palletsprojects.com/p/jinja/) templating syntax to interpolate the query, if desired. `db.result()` inspects the query for template tags (`"{%.*%}"`) and renders the template to SQL before submitting if tags are present. (It uses a `SandboxedEnvironment` for some measure of injection safety, but avoid this option with untrusted inputs, for obvious reasons.)
+
+### Options
+
+Passing argument `returns` to `db.result()` (or `result_from_file()`) overrides the default result formatting: `returns="tuples"` brings back a list of tuples with row values instead of dictionaries, and `returns="proxy"` returns the plain SQLAlchemy [ResultProxy](https://docs.sqlalchemy.org/en/latest/core/connections.html?highlight=resultproxy#sqlalchemy.engine.ResultProxy) object directly, for further handling by the caller. `"proxy"` allows access to methods (e.g. `fetchone()` or `fetchmany()` ) that `sqla-raw` default usage hides behind its facade; it can also be good for SQL statements (like `inserts` without `returning` or DDL) that are not expected to return results — although by default these will return an empty list.
 
 
 ## Tests
 
-`pytest` tests are located in [tests/](tests/). Install test prerequisites with `pip install -r tests/requirements.txt`, then they can be run with: `python setup.py test` 
+`pytest` tests are located in [tests/](tests/). Install test prerequisites with `pip install -r tests/requirements.txt`; then they can be run with: `python setup.py test` 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = "https://github.com/tym-xqo/sqla-raw"
 EMAIL = "thomas@yager-madden.com"
 AUTHOR = "Thomas Yager-Madden"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.4.1"
+VERSION = "0.5.0"
 
 REQUIRED = [
     "jinja2",
@@ -112,6 +112,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Database :: Front-Ends",
         "Topic :: Software Development :: Libraries",
         "Topic :: Utilities",

--- a/tests/sql_files/bad.sql
+++ b/tests/sql_files/bad.sql
@@ -1,1 +1,1 @@
-SELECT * FROM nonexistent_relation;
+select * from nonexistent_relation;

--- a/tests/sql_files/good.sql
+++ b/tests/sql_files/good.sql
@@ -1,1 +1,6 @@
-SELECT 'bar' as foo;
+select 'bar' as foo
+{% if more %}
+union
+select 'baz' as quux
+{% endif %}
+;

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2,25 +2,44 @@ import os
 
 import pytest
 import sqlalchemy.exc
+from sqlalchemy.engine.result import ResultProxy
+
 from raw.db import result, result_from_file
 
 os.environ["DATABASE_URL"] = "sqlite:///"
 
 
-def test_result(caplog):
+def test_result():
     # trigger an error, and verify it is raised
     with pytest.raises(sqlalchemy.exc.OperationalError):
-        result("SELECT * FROM nonexistent_relation")
+        result("select * from nonexistent_relation")
 
-    # execution should still be possible
-    r = result("SELECT 'bar' as foo;")
+    # execute valid SQL and verify results
+    r = result("select 'bar' as foo;")
     assert r == [{"foo": "bar"}]
 
 
-def test_result_from_file(caplog):
+def test_result_from_file():
     # trigger an error, and verify it is raised
     with pytest.raises(sqlalchemy.exc.OperationalError):
         result_from_file("./tests/sql_files/bad.sql")
 
-    # execution should still be possible
-    result_from_file("./tests/sql_files/good.sql")
+    # execute SQL from file, verify results in tuple format using Jinja2
+    r = result_from_file("./tests/sql_files/good.sql", returns="tuples", more=True)
+    assert r == [("bar",), ("baz",)]
+
+
+def test_proxy_result():
+    r = result("select 'bar' as foo;", returns="proxy")
+    assert isinstance(r, ResultProxy)
+    row = r.fetchone()
+    assert row.foo == "bar"
+
+
+def test_ddl_result():
+    result("create table if not exists foo (id int, bar text)", returns="proxy")
+    result("insert into foo values (1, 'baz')")
+    r = result("select * from foo", returns="tuples")
+    assert r == [
+        (1, "baz"),
+    ]


### PR DESCRIPTION
- can specify results as tuples or sqla ResultProxy object
- append application_name to DATABASE_URL
- add tests to get coverage up to 100%
- expand and revise README