### PR TITLE
Add `result_by_name()` method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
-DATABASE_URL=postgres://thomas@localhost/yardstick
+DATABASE_URL=sqlite:///
+APPLICATION_NAME=script/sqla-raw
+QUERY_PATH=query_files

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 .vscode/settings.json
+
+# Local query files
+query_files/*
+!query_files/README.md

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An opinionated, minimalist library for fetching data from a [SQLAlchemy](https:/
 
 Really not much more than a single method (`raw.db.result()`) that submits raw SQL via a SQLAlchemy [Engine](https://docs.sqlalchemy.org/en/latest/core/connections.html#sqlalchemy.engine.Engine) connection. By default, `db.result()` returns all results as a list of dictionaries, keyed by column names. (See __'Usage'__ below for other options)
 
-As a convenience, `result_from_file()` is about the same except that it reads your query from a given path, rather than taking a SQL string argument directly. Contents of the file are handed off to `result()` so the rest functions identitically.
+For convenience, `result_from_file()` and `result_by_name()` allow you to store your SQL in separate local files for submission to the database via `result()`
 
 Engine instantiation is handled implicitly by the first call to `result()`; any subsequent calls use a connection from the pool. The connection string for the Engine is set by `DATABASE_URL` in the environment. All other Engine settings use SQLAlchemy defaults. (Affording explicit creation and disposal of the Engine and exposing the setting of other parameters might be a useful area for further development, if it can be kept simple.)
 
@@ -38,7 +38,13 @@ You can also use [Jinja2](https://palletsprojects.com/p/jinja/) templating synta
 
 Passing argument `returns` to `db.result()` (or `result_from_file()`) overrides the default result formatting: `returns="tuples"` brings back a list of tuples with row values instead of dictionaries, and `returns="proxy"` returns the plain SQLAlchemy [ResultProxy](https://docs.sqlalchemy.org/en/latest/core/connections.html?highlight=resultproxy#sqlalchemy.engine.ResultProxy) object directly, for further handling by the caller. The `"proxy"` option allows access to methods (e.g. `fetchone()` or `fetchmany()` ) that `sqla-raw` default usage hides behind its facade; it can also be good for SQL statements (such as `inserts` without `returning` or DDL) that are not expected to return results — although by default these will return an empty list.
 
+### SQL file handling
 
+For longer or more complex queries, it is generally more convenient and maintainable to save your SQL in its own file, rather than include it inline in your Python program. Doing so also allows the queries to be tested and/or reused in your preferred database client tool. `sqla-raw` provides two ways to do this:
+
+`result_from_file()` takes a path (any file-like object should also work) and reads your query from there, rather than taking a SQL string argument directly. Contents of the file are handed off to result() so the rest functions identitically.
+
+`result_by_name()` looks for SQL files in a local directory — `${PWD}/query_files` by default, or you may specify any arbitrary filesystem location by setting `$QUERY_PATH` in the environment. The `query_name` arguement is the [stem](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.stem) of the desired file.
 ## Tests
 
 `pytest` tests are located in [tests/](tests/). Install test prerequisites with `pip install -r tests/requirements.txt`; then they can be run with: `python setup.py test` 

--- a/raw/db.py
+++ b/raw/db.py
@@ -4,6 +4,7 @@
 """
 import os
 import re
+from pathlib import Path
 
 from jinja2.sandbox import SandboxedEnvironment
 from sqlalchemy import create_engine, text
@@ -88,3 +89,21 @@ def result_from_file(path, returns="dict", **kwargs):
         sql = f.read()
         rows = result(sql=sql, returns=returns, **kwargs)
         return rows
+
+
+def path_by_name(query_name):
+    """Find file matching query_name and return Path object"""
+    # flatten directory and grab all the leaf nodes
+    flat_queries = list(Path(os.getenv("QUERY_PATH", "query_files")).glob("**/*"))
+    query_file = None
+    query_file_match = list(filter(lambda i: query_name == i.stem, flat_queries))
+    if query_file_match:
+        # TODO: Warn if more than one match
+        query_file = query_file_match[0]
+    return query_file
+
+
+def result_by_name(query_name, returns="dict", **kwargs):
+    path = path_by_name(query_name)
+    result = result_from_file(path=path, returns=returns, **kwargs)
+    return result

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = "https://github.com/tym-xqo/sqla-raw"
 EMAIL = "thomas@yager-madden.com"
 AUTHOR = "Thomas Yager-Madden"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.5.0"
+VERSION = "1.0.0-rc.1"
 
 REQUIRED = [
     "jinja2",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,12 +1,15 @@
 import os
+from pathlib import Path
 
 import pytest
 import sqlalchemy.exc
 from sqlalchemy.engine.result import ResultProxy
 
-from raw.db import result, result_from_file
+from raw.db import result, result_from_file, result_by_name
 
 os.environ["DATABASE_URL"] = "sqlite:///"
+query_path = Path(__file__).resolve().parent / "sql_files"
+os.environ["QUERY_PATH"] = str(query_path)
 
 
 def test_result():
@@ -26,6 +29,16 @@ def test_result_from_file():
 
     # execute SQL from file, verify results in tuple format using Jinja2
     r = result_from_file("./tests/sql_files/good.sql", returns="tuples", more=True)
+    assert r == [("bar",), ("baz",)]
+
+
+def test_result_by_name():
+    # trigger an error, and verify it is raised
+    with pytest.raises(sqlalchemy.exc.OperationalError):
+        result_by_name("bad")
+
+    # execute SQL from file, verify results in tuple format using Jinja2
+    r = result_by_name("good", returns="tuples", more=True)
     assert r == [("bar",), ("baz",)]
 
 


### PR DESCRIPTION
Takes a file stem name, searches for it in a local directory (at `QUERY_PATH` or `${PWD}/query_files by default), and hands off to `result()`