### PR TITLE
Add `engine()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ An opinionated, minimalist library for fetching data from a [SQLAlchemy](https:/
 
 Really not much more than a single method (`raw.db.result()`) that submits raw SQL via a SQLAlchemy [Engine](https://docs.sqlalchemy.org/en/latest/core/connections.html#sqlalchemy.engine.Engine) connection. By default, `db.result()` returns all results as a list of dictionaries, keyed by column names. (See __'Usage'__ below for other options)
 
-For convenience, `result_from_file()` and `result_by_name()` allow you to store your SQL in separate local files for submission to the database via `result()`
-
-Engine instantiation is handled implicitly by the first call to `result()`; any subsequent calls use a connection from the pool. The connection string for the Engine is set by `DATABASE_URL` in the environment. All other Engine settings use SQLAlchemy defaults. (Affording explicit creation and disposal of the Engine and exposing the setting of other parameters might be a useful area for further development, if it can be kept simple.)
+For convenience, `result_from_file()` and `result_by_name()` allow you to store your SQL in separate local files for submission to the database via `result()` 
 
 ## Installation
 
@@ -45,6 +43,12 @@ For longer or more complex queries, you may find it more convenient and maintain
 `result_from_file()` takes a path (any file-like object should also work) and reads your query from there, rather than taking a SQL string argument directly. Contents of the file are handed off to result() so the rest functions identitically.
 
 `result_by_name()` looks for SQL files in a local directory — `${PWD}/query_files` by default, or you may specify any arbitrary filesystem location by setting `$QUERY_PATH` in the environment. The `query_name` arguement is the [stem](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.stem) of the desired file.
+
+### SQLAlchemy Engine invocation
+
+By default, Engine instantiation is handled implicitly on first call to `result()`; subsquent calls use a connection from the pool. The default connection string for the Engine is set by `DATABASE_URL` in the environment, and all other Engine settings use SQLAlchemy defaults. This allows you to simply call `result()` and start querying `$DATABASE_URL` immediately with a minimum of fuss. 
+
+In case you require multiple database connections, or more control over Engine parameters, `db.engine()` wraps `sqlalchemy.create_engine()`, so you can set a different connection string or pass additional settings as keyword arguments (see https://docs.sqlalchemy.org/en/14/core/engines.html for options). Once `db.engine()` is explicitly invoked, the engine so instantiated remains as the active connection pool unless changed again.
 
 ### Exception handling
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Obviously, when interacting with a database, any number of things can go wrong, 
 
 ## Alternatives and prior art
 
-These are all fine projects, and if `sqla-raw` appeals to you at all, you owe it to yourself to take a look at them. For starters, any of them would give you more control over how and when to instantiate your database connection. These and `sqla-raw` are all similar tools with similar SQL-first, non-ORM philosophies. I haven't benchmarked performance for any one of them, but 3 out of 4 use SQLAlchemy under the covers, and I'd be surprised if there are big differences amoung at least those three. Until some notable difference in performance turns up, the best choice for you is most likely a matter of taste.
+These are all fine projects, and if `sqla-raw` appeals to you at all, you owe it to yourself to take a look at them. These and `sqla-raw` are all similar tools with similar SQL-first, non-ORM philosophies. I haven't benchmarked performance for any one of them, but 3 out of 4 use SQLAlchemy under the covers, and I'd be surprised if there are big differences among at least those three. Until some notable difference in performance turns up, the best choice for you is most likely a matter of taste.
 
 - [aiosql](https://github.com/nackjicholson/aiosql) 
   - Supports standard and async I/O
   - Turns SQL files into callable methods
-    - Nothing wrong with that, but differernt from the interface chosen for `sqla-raw` (which takes the SQL or file name as argument to a single `result()` method)
+    - Nothing wrong with that, but different from the interface chosen for `sqla-raw` (which takes the SQL or file name as argument to a single `result()` method)
     - Relies on special comments in the SQL
   - Not SQLAlchemy; supports a more limited set of database drivers
   - Doesn't handle database connect instantiation (expects to be given a conn object)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = "https://github.com/nerium-data/sqla-raw"
 EMAIL = "thomas@yager-madden.com"
 AUTHOR = "Thomas Yager-Madden"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 
 REQUIRED = [
     "jinja2",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -5,7 +5,7 @@ import pytest
 import sqlalchemy.exc
 from sqlalchemy.engine.result import ResultProxy
 
-from raw.db import result, result_from_file, result_by_name
+from raw.db import engine, result, result_from_file, result_by_name
 
 os.environ["DATABASE_URL"] = "sqlite:///"
 query_path = Path(__file__).resolve().parent / "sql_files"
@@ -43,6 +43,7 @@ def test_result_by_name():
 
 
 def test_proxy_result():
+    engine()
     r = result("select 'bar' as foo;", returns="proxy")
     assert isinstance(r, ResultProxy)
     row = r.fetchone()
@@ -50,6 +51,7 @@ def test_proxy_result():
 
 
 def test_ddl_result():
+    engine()
     result("create table if not exists foo (id int, bar text)", returns="proxy")
     result("insert into foo values (1, 'baz')")
     r = result("select * from foo", returns="tuples")


### PR DESCRIPTION
- Affords connection string override, in order to support multiple connections in a single program
- Also passes kwargs to sqla.create_engine() to allow control of other Engine parameters