### PR TITLE
Remove sqlite default if DATABASE URL not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Configure your database connection string by setting `$DATABASE_URL` in your env
 >>> from raw import db
 >>> x = db.result('select version()');
 >>> x
-[{'version': 'PostgreSQL 10.10 on x86_64-apple-darwin14.5.0, compiled by Apple LLVM version 7.0.0 (clang-700.1.76), 64-bit'}]
+[{'version': 'PostgreSQL 13.4 on x86_64-apple-darwin19.6.0, compiled by Apple clang version 11.0.3 (clang-1103.0.32.62), 64-bit'}]
 ```
 
 Because it's SQLAlchemy, you can safely use [named parameters](https://docs.sqlalchemy.org/en/latest/core/sqlelement.html?highlight=textclause#sqlalchemy.sql.expression.TextClause.bindparams) in your SQL string with colon-prepended `:key` format, and assign values in `kwargs`.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = "https://github.com/nerium-data/sqla-raw"
 EMAIL = "thomas@yager-madden.com"
 AUTHOR = "Thomas Yager-Madden"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "1.1.2"
+VERSION = "1.2.0"
 
 REQUIRED = [
     "jinja2",


### PR DESCRIPTION
- Raise ValueError instead
- Add test to ensure exception if dburl not specified
- set DATABASE_URL for other tests using mock in fixture

Having in-memory sqlite database as default fallback in case `$DATABASE_URL` not set in environment can lead to mysterious errors. Better to raise an exception and remind the operator to set a database url.